### PR TITLE
additional temperatue values of S.M.A.R.T.

### DIFF
--- a/files/node-exporter/node_exporter-smartmon
+++ b/files/node-exporter/node_exporter-smartmon
@@ -45,7 +45,9 @@ sata_downshift_count
 spin_retry_count
 spin_up_time
 start_stop_count
+temperature_case
 temperature_celsius
+temperature_internal
 total_lbas_read
 total_lbas_written
 udma_crc_error_count


### PR DESCRIPTION
added S.M.A.R.T. temperature values for some Intel disks
# smartctl -i -H -d sat /dev/sda
smartctl 6.5 2016-01-24 r4214 [x86_64-linux-4.4.0-92-generic] (local build)
Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Intel 730 and DC S35x0/3610/3700 Series SSDs
Device Model:     INTEL SSDSC2BB240G7
Serial Number:    PHDV716402YR240AGN
LU WWN Device Id: 5 5cd2e4 14d7afbba
Firmware Version: N2010112
User Capacity:    240,057,409,536 bytes [240 GB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Tue Mar 20 22:40:49 2018 UTC
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART Status not supported: Incomplete response, ATA output registers missing
SMART overall-health self-assessment test result: PASSED
Warning: This result is based on an Attribute check.
# smartctl -A -d sat /dev/sda | grep -i temperature
190 Temperature_Case        0x0022   074   069   000    Old_age   Always       -       26 (Min/Max 24/31)
194 Temperature_Internal    0x0022   100   100   000    Old_age   Always       -       26

# smartctl -i -H -d sat /dev/sdb
smartctl 6.5 2016-01-24 r4214 [x86_64-linux-4.4.0-92-generic] (local build)
Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Device Model:     INTEL SSDSC2BB016T7
Serial Number:    PHDV701403GE1P6EGN
LU WWN Device Id: 5 5cd2e4 14d6017a8
Firmware Version: N2010101
User Capacity:    1,600,321,314,816 bytes [1.60 TB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
Device is:        Not in smartctl database [for details use: -P showall]
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Tue Mar 20 22:40:52 2018 UTC
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART Status not supported: Incomplete response, ATA output registers missing
SMART overall-health self-assessment test result: PASSED
Warning: This result is based on an Attribute check.
# smartctl -A -d sat /dev/sdb | grep -i temperature
190 Airflow_Temperature_Cel 0x0022   074   063   000    Old_age   Always       -       26 (Min/Max 25/37)
194 Temperature_Celsius     0x0022   100   100   000    Old_age   Always       -       26

